### PR TITLE
Change arguments type

### DIFF
--- a/lib/client.spec.ts
+++ b/lib/client.spec.ts
@@ -29,15 +29,13 @@ describe('client.ts', () => {
 
 	describe('contractFactory', () => {
 		it('check return object', () => {
-			const host = 'localhost'
-
 			const client = new Web3()
 
-			client.setProvider(new Web3.providers.HttpProvider(host))
+			client.setProvider(new Web3.providers.HttpProvider('localhost'))
 
 			const expected = createDevkitContract(client)
 
-			const result = contractFactory(host)
+			const result = contractFactory(client.currentProvider)
 
 			expect(JSON.stringify(result)).toEqual(JSON.stringify(expected))
 		})

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -1,4 +1,5 @@
 import Web3 from 'web3'
+import { Provider } from 'web3/providers'
 import { createMarketContract } from './market/index'
 import { createPropertyContract } from './property/index'
 import { createPropertyFactoryContract } from './property-factory/index'
@@ -18,13 +19,8 @@ export const createDevkitContract = (client: Web3): DevkitContract => ({
 	propertyFactory: createPropertyFactoryContract(client)
 })
 
-export const contractFactory = (
-	host: string,
-	timeout?: number
-): DevkitContract => {
-	const client = new Web3()
-
-	client.setProvider(new Web3.providers.HttpProvider(host, timeout))
+export const contractFactory = (provider: Provider): DevkitContract => {
+	const client = new Web3(provider)
 
 	return createDevkitContract(client)
 }


### PR DESCRIPTION
## Proposed Changes

Changes the `contractFactory` method's arguments to Web3 Provider.

A web browser has a `window.ethereum` object injected by a Dapp wallet. Just pass this.

This change, I merge if the test passes.