### PR TITLE
add definition of capSetter method into policy abi

### DIFF
--- a/lib/policy/abi.ts
+++ b/lib/policy/abi.ts
@@ -197,4 +197,19 @@ export const policyAbi = [
 		stateMutability: 'view',
 		type: 'function',
 	},
+	{
+		constant: true,
+		inputs: [],
+		name: 'capSetter',
+		outputs: [
+			{
+				internalType: 'address',
+				name: '',
+				type: 'address',
+			},
+		],
+		payable: false,
+		stateMutability: 'view',
+		type: 'function',
+	},
 ] as readonly AbiItem[]


### PR DESCRIPTION
Fixes https://github.com/dev-protocol/stakes.social/issues/1334

## Proposed Changes

- add `capSetter` method definition in policy contarct abi, because not exists `capSetter` method definition
- If the definition does not exist, the following error will occur

```
    TypeError: m is not a function

      75 | 	const a =
      76 | 		args !== undefined && padEnd !== undefined ? pad(args, padEnd) : args
    > 77 | 	const x = a ? m(...a) : m()
         | 	                        ^
      78 | 	return mutation === true
      79 | 		? txPromisify(x.send({ from: await getAccount(client as Web3) })).then(
      80 | 				(receipt) => receipt

      at lib/utils/execute.ts:77:26
      at lib/utils/execute.ts:8:71
      at Object.<anonymous>.__awaiter (lib/utils/execute.ts:4:12)
      at Object.execute (lib/utils/execute.ts:73:27)
      at Object.createCapSetterCaller (lib/policy/capSetter.ts:14:3)
      at lib/policy/capSetter.spec.ts:63:19
      at fulfilled (lib/policy/capSetter.spec.ts:5:58)
```

You can use [this changeset](https://github.com/hhatto/dev-kit-js/commit/29634bdc1a5ac28b401ba53e844289f6ca70fd6e) to reproduction it.

```
$ WEB3_PROVIDER=YOUR_WEB3_PROVIDER yarn test
```