### PR TITLE
feat: changed the provider of the RockUp API from web3 to ethers.js

### DIFF
--- a/lib/lockup/abi.ts
+++ b/lib/lockup/abi.ts
@@ -1,5 +1,3 @@
-import { AbiItem } from 'web3-utils'
-
 export const lockupAbi = [
 	{
 		inputs: [
@@ -820,4 +818,4 @@ export const lockupAbi = [
 		stateMutability: 'nonpayable',
 		type: 'function',
 	},
-] as readonly AbiItem[]
+]

--- a/lib/lockup/calculateWithdrawableInterestAmount.spec.ts
+++ b/lib/lockup/calculateWithdrawableInterestAmount.spec.ts
@@ -6,18 +6,14 @@ describe('calculateWithdrawableInterestAmount.spec.ts', () => {
 			const value = 'value'
 
 			const lockupContract = {
-				methods: {
-					calculateWithdrawableInterestAmount: (
+				calculateWithdrawableInterestAmount: jest
+					.fn()
+					.mockImplementation(async (
 						// eslint-disable-next-line @typescript-eslint/no-unused-vars
 						propertyAddress: string,
 						// eslint-disable-next-line @typescript-eslint/no-unused-vars
 						address: string
-					) => ({
-						call: jest
-							.fn()
-							.mockImplementation(async () => Promise.resolve(value)),
-					}),
-				},
+					) => Promise.resolve(value)),
 			}
 
 			const expected = value
@@ -39,18 +35,14 @@ describe('calculateWithdrawableInterestAmount.spec.ts', () => {
 			const error = 'error'
 
 			const lockupContract = {
-				methods: {
-					calculateWithdrawableInterestAmount: (
+				calculateWithdrawableInterestAmount: jest
+					.fn()
+					.mockImplementation(async (
 						// eslint-disable-next-line @typescript-eslint/no-unused-vars
 						propertyAddress: string,
 						// eslint-disable-next-line @typescript-eslint/no-unused-vars
 						address: string
-					) => ({
-						call: jest
-							.fn()
-							.mockImplementation(async () => Promise.reject(error)),
-					}),
-				},
+					) => Promise.reject(error)),
 			}
 
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/lib/lockup/calculateWithdrawableInterestAmount.ts
+++ b/lib/lockup/calculateWithdrawableInterestAmount.ts
@@ -1,15 +1,16 @@
-import { Contract } from 'web3-eth-contract/types'
-import { execute } from '../utils/execute'
+import { ethers } from 'ethers'
+import { execute, QueryOption } from '../utils/ethers-execute'
 
 export type CreateCalculateWithdrawableInterestAmountCaller = (
-	contract: Contract
+	contract: ethers.Contract
 ) => (propertyAddress: string, account: string) => Promise<string>
 
 export const createCalculateWithdrawableInterestAmountCaller: CreateCalculateWithdrawableInterestAmountCaller = (
-	contract: Contract
+	contract: ethers.Contract
 ) => async (propertyAddress: string, account: string) =>
-	execute({
+	execute<QueryOption>({
 		contract,
 		method: 'calculateWithdrawableInterestAmount',
 		args: [propertyAddress, account],
+		mutation: false,
 	})

--- a/lib/lockup/cancel.spec.ts
+++ b/lib/lockup/cancel.spec.ts
@@ -1,5 +1,5 @@
 import { createCancelCaller } from './cancel'
-import { stubbedWeb3, stubbedSendTx } from '../utils/for-test'
+import { stubbedSendTx } from '../utils/for-test'
 
 describe('cancel.spec.ts', () => {
 	describe('createCancelCaller', () => {
@@ -7,18 +7,15 @@ describe('cancel.spec.ts', () => {
 			const value = true
 
 			const lockupContract = {
-				methods: {
+				cancel: jest
+					.fn()
 					// eslint-disable-next-line @typescript-eslint/no-unused-vars
-					cancel: (property: string) => ({
-						send: jest.fn().mockImplementation(async () => stubbedSendTx()),
-					}),
-				},
+					.mockImplementation(async (property: string) => stubbedSendTx()),
 			}
 
 			const expected = value
 
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			const caller = createCancelCaller(lockupContract as any, stubbedWeb3)
+			const caller = createCancelCaller(lockupContract as any)
 
 			const result = await caller('0x80a25ACDD0797dfCe02dA25e4a55A4a334EE51c5')
 
@@ -26,25 +23,23 @@ describe('cancel.spec.ts', () => {
 		})
 
 		it('call failure', async () => {
+			const error = 'error'
 			const lockupContract = {
-				methods: {
+				cancel: jest
+					.fn()
 					// eslint-disable-next-line @typescript-eslint/no-unused-vars
-					cancel: (property: string) => ({
-						send: jest
-							.fn()
-							.mockImplementation(async () => stubbedSendTx(undefined, true)),
-					}),
-				},
+					.mockImplementation(async (property: string) =>
+						Promise.reject(error)
+					),
 			}
 
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			const caller = createCancelCaller(lockupContract as any, stubbedWeb3)
+			const caller = createCancelCaller(lockupContract as any)
 
 			const result = await caller(
 				'0x80a25ACDD0797dfCe02dA25e4a55A4a334EE51c5'
 			).catch((err) => err)
 
-			expect(result).toBeInstanceOf(Error)
+			expect(result).toEqual(error)
 		})
 	})
 })

--- a/lib/lockup/cancel.ts
+++ b/lib/lockup/cancel.ts
@@ -1,21 +1,17 @@
-import { Contract } from 'web3-eth-contract/types'
-import Web3 from 'web3'
-import { execute } from '../utils/execute'
+import { ethers } from 'ethers'
+import { execute, MutationOption } from '../utils/ethers-execute'
 import { T } from 'ramda'
 
 export type CreateCancelCaller = (
-	contract: Contract,
-	client: Web3
+	contract: ethers.Contract
 ) => (propertyAddress: string) => Promise<boolean>
 
 export const createCancelCaller: CreateCancelCaller = (
-	contract: Contract,
-	client: Web3
+	contract: ethers.Contract
 ) => async (propertyAddress: string) =>
-	execute({
+	execute<MutationOption>({
 		contract,
 		method: 'cancel',
-		mutation: true,
-		client,
 		args: [propertyAddress],
+		mutation: true,
 	}).then(T)

--- a/lib/lockup/getAllValue.spec.ts
+++ b/lib/lockup/getAllValue.spec.ts
@@ -6,18 +6,13 @@ describe('getAllValue.spec.ts', () => {
 			const value = 'value'
 
 			const lockupContract = {
-				methods: {
-					getAllValue: () => ({
-						call: jest
-							.fn()
-							.mockImplementation(async () => Promise.resolve(value)),
-					}),
-				},
+				getAllValue: jest
+					.fn()
+					.mockImplementation(async () => Promise.resolve(value)),
 			}
 
 			const expected = value
 
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			const caller = createGetAllValueCaller(lockupContract as any)
 
 			const result = await caller()
@@ -29,14 +24,12 @@ describe('getAllValue.spec.ts', () => {
 			const error = 'error'
 
 			const lockupContract = {
-				methods: {
-					// eslint-disable-next-line @typescript-eslint/no-unused-vars
-					getAllValue: (property: string, account: string) => ({
-						call: jest
-							.fn()
-							.mockImplementation(async () => Promise.reject(error)),
-					}),
-				},
+				// eslint-disable-next-line @typescript-eslint/no-unused-vars
+				getAllValue: jest
+					.fn()
+					.mockImplementation(async (property: string, account: string) =>
+						Promise.reject(error)
+					),
 			}
 
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/lib/lockup/getAllValue.ts
+++ b/lib/lockup/getAllValue.ts
@@ -1,11 +1,18 @@
-import { Contract } from 'web3-eth-contract/types'
-import { execute } from '../utils/execute'
+import { ethers } from 'ethers'
+import { execute, QueryOption } from '../utils/ethers-execute'
 import { always } from 'ramda'
 
 export type CreateGetAllValueCaller = (
-	contract: Contract
+	contract: ethers.Contract
 ) => () => Promise<string>
 
 export const createGetAllValueCaller: CreateGetAllValueCaller = (
-	contract: Contract
-) => always(execute({ contract, method: 'getAllValue' }))
+	contract: ethers.Contract
+) =>
+	always(
+		execute<QueryOption>({
+			contract,
+			method: 'getAllValue',
+			mutation: false,
+		})
+	)

--- a/lib/lockup/getPropertyValue.spec.ts
+++ b/lib/lockup/getPropertyValue.spec.ts
@@ -6,14 +6,12 @@ describe('getPropertyValue.spec.ts', () => {
 			const value = 'value'
 
 			const lockupContract = {
-				methods: {
+				getPropertyValue: jest
+					.fn()
 					// eslint-disable-next-line @typescript-eslint/no-unused-vars
-					getPropertyValue: (address: string) => ({
-						call: jest
-							.fn()
-							.mockImplementation(async () => Promise.resolve(value)),
-					}),
-				},
+					.mockImplementation(async (address: string) =>
+						Promise.resolve(value)
+					),
 			}
 
 			const expected = value
@@ -30,14 +28,10 @@ describe('getPropertyValue.spec.ts', () => {
 			const error = 'error'
 
 			const lockupContract = {
-				methods: {
+				getPropertyValue: jest
+					.fn()
 					// eslint-disable-next-line @typescript-eslint/no-unused-vars
-					getPropertyValue: (address: string) => ({
-						call: jest
-							.fn()
-							.mockImplementation(async () => Promise.reject(error)),
-					}),
-				},
+					.mockImplementation(async (address: string) => Promise.reject(error)),
 			}
 
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/lib/lockup/getPropertyValue.ts
+++ b/lib/lockup/getPropertyValue.ts
@@ -1,11 +1,16 @@
-import { Contract } from 'web3-eth-contract/types'
-import { execute } from '../utils/execute'
+import { ethers } from 'ethers'
+import { execute, QueryOption } from '../utils/ethers-execute'
 
 export type CreateGetPropertyValueCaller = (
-	contract: Contract
+	contract: ethers.Contract
 ) => (address: string) => Promise<string>
 
 export const createGetPropertyValueCaller: CreateGetPropertyValueCaller = (
-	contract: Contract
+	contract: ethers.Contract
 ) => async (address: string) =>
-	execute({ contract, method: 'getPropertyValue', args: [address] })
+	execute<QueryOption>({
+		contract,
+		method: 'getPropertyValue',
+		args: [address],
+		mutation: false,
+	})

--- a/lib/lockup/getStorageWithdrawalStatus.spec.ts
+++ b/lib/lockup/getStorageWithdrawalStatus.spec.ts
@@ -6,14 +6,12 @@ describe('getStorageWithdrawalStatus.spec.ts', () => {
 			const value = 'value'
 
 			const lockupContract = {
-				methods: {
+				getStorageWithdrawalStatus: jest
+					.fn()
 					// eslint-disable-next-line @typescript-eslint/no-unused-vars
-					getStorageWithdrawalStatus: (property: string, account: string) => ({
-						call: jest
-							.fn()
-							.mockImplementation(async () => Promise.resolve(value)),
-					}),
-				},
+					.mockImplementation(async (property: string, account: string) =>
+						Promise.resolve(value)
+					),
 			}
 
 			const expected = value
@@ -35,14 +33,12 @@ describe('getStorageWithdrawalStatus.spec.ts', () => {
 			const error = 'error'
 
 			const lockupContract = {
-				methods: {
+				getStorageWithdrawalStatus: jest
+					.fn()
 					// eslint-disable-next-line @typescript-eslint/no-unused-vars
-					getStorageWithdrawalStatus: (property: string, account: string) => ({
-						call: jest
-							.fn()
-							.mockImplementation(async () => Promise.reject(error)),
-					}),
-				},
+					.mockImplementation(async (property: string, account: string) =>
+						Promise.reject(error)
+					),
 			}
 
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/lib/lockup/getStorageWithdrawalStatus.ts
+++ b/lib/lockup/getStorageWithdrawalStatus.ts
@@ -1,15 +1,16 @@
-import { Contract } from 'web3-eth-contract/types'
-import { execute } from '../utils/execute'
+import { ethers } from 'ethers'
+import { execute, QueryOption } from '../utils/ethers-execute'
 
 export type CreateGetStorageWithdrawalStatusCaller = (
-	contract: Contract
+	contract: ethers.Contract
 ) => (propertyAddress: string, accountAddress: string) => Promise<string>
 
 export const createGetStorageWithdrawalStatusCaller: CreateGetStorageWithdrawalStatusCaller = (
-	contract: Contract
+	contract: ethers.Contract
 ) => async (propertyAddress: string, accountAddress: string) =>
-	execute({
+	execute<QueryOption>({
 		contract,
 		method: 'getStorageWithdrawalStatus',
 		args: [propertyAddress, accountAddress],
+		mutation: false,
 	})

--- a/lib/lockup/getValue.spec.ts
+++ b/lib/lockup/getValue.spec.ts
@@ -6,14 +6,12 @@ describe('getValue.spec.ts', () => {
 			const value = 'value'
 
 			const lockupContract = {
-				methods: {
+				getValue: jest
+					.fn()
 					// eslint-disable-next-line @typescript-eslint/no-unused-vars
-					getValue: (property: string, account: string) => ({
-						call: jest
-							.fn()
-							.mockImplementation(async () => Promise.resolve(value)),
-					}),
-				},
+					.mockImplementation(async (property: string, account: string) =>
+						Promise.resolve(value)
+					),
 			}
 
 			const expected = value
@@ -33,14 +31,12 @@ describe('getValue.spec.ts', () => {
 			const error = 'error'
 
 			const lockupContract = {
-				methods: {
+				getValue: jest
+					.fn()
 					// eslint-disable-next-line @typescript-eslint/no-unused-vars
-					getValue: (property: string, account: string) => ({
-						call: jest
-							.fn()
-							.mockImplementation(async () => Promise.reject(error)),
-					}),
-				},
+					.mockImplementation(async (property: string, account: string) =>
+						Promise.reject(error)
+					),
 			}
 
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/lib/lockup/getValue.ts
+++ b/lib/lockup/getValue.ts
@@ -1,15 +1,16 @@
-import { Contract } from 'web3-eth-contract/types'
-import { execute } from '../utils/execute'
+import { ethers } from 'ethers'
+import { execute, QueryOption } from '../utils/ethers-execute'
 
 export type CreateGetValueCaller = (
-	contract: Contract
+	contract: ethers.Contract
 ) => (propertyAddress: string, accountAddress: string) => Promise<string>
 
 export const createGetValueCaller: CreateGetValueCaller = (
-	contract: Contract
+	contract: ethers.Contract
 ) => async (propertyAddress: string, accountAddress: string) =>
-	execute({
+	execute<QueryOption>({
 		contract,
 		method: 'getValue',
 		args: [propertyAddress, accountAddress],
+		mutation: false,
 	})

--- a/lib/lockup/index.spec.ts
+++ b/lib/lockup/index.spec.ts
@@ -1,8 +1,7 @@
-import Web3 from 'web3'
+import { ethers } from 'ethers'
 import { createLockupContract, LockupContract } from '.'
 import { createGetValueCaller } from './getValue'
 import { lockupAbi } from './abi'
-import { CustomOptions } from '../option'
 import { createGetPropertyValueCaller } from './getPropertyValue'
 import { createCancelCaller } from './cancel'
 import { createWithdrawCaller } from './withdraw'
@@ -11,47 +10,67 @@ import { createCalculateWithdrawableInterestAmountCaller } from './calculateWith
 import { createGetAllValueCaller } from './getAllValue'
 import { createGetStorageWithdrawalStatusCaller } from './getStorageWithdrawalStatus'
 
+jest.mock('./getPropertyValue')
+jest.mock('./cancel')
+jest.mock('./withdraw')
+jest.mock('./withdrawInterest')
+jest.mock('./calculateWithdrawableInterestAmount')
+jest.mock('./getAllValue')
+jest.mock('./getStorageWithdrawalStatus')
+
 describe('lockup/index.ts', () => {
+	;(createGetPropertyValueCaller as jest.Mock).mockImplementation(
+		(contract) => contract
+	)
+	;(createCancelCaller as jest.Mock).mockImplementation((contract) => contract)
+	;(createWithdrawCaller as jest.Mock).mockImplementation(
+		(contract) => contract
+	)
+	;(createWithdrawInterestCaller as jest.Mock).mockImplementation(
+		(contract) => contract
+	)
+	;(createCalculateWithdrawableInterestAmountCaller as jest.Mock).mockImplementation(
+		(contract) => contract
+	)
+	;(createGetAllValueCaller as jest.Mock).mockImplementation(
+		(contract) => contract
+	)
+	;(createGetStorageWithdrawalStatusCaller as jest.Mock).mockImplementation(
+		(contract) => contract
+	)
 	describe('createLockupContract', () => {
 		it('check return object', () => {
 			const host = 'localhost'
-			const client = new Web3()
-			client.setProvider(new Web3.providers.HttpProvider(host))
+			const address = 'address'
 
-			const expected: (
-				address?: string,
-				options?: CustomOptions
-			) => LockupContract = (address?: string, options?: CustomOptions) => {
-				const lockupContract = new client.eth.Contract(
-					[...lockupAbi],
-					address,
-					{
-						...options,
-					}
-				)
+			const provider = new ethers.providers.JsonRpcProvider(host)
+
+			const expected: (address: string) => LockupContract = (
+				address: string
+			) => {
+				const contract = new ethers.Contract(address, [...lockupAbi], provider)
 				return {
-					getValue: createGetValueCaller(lockupContract),
-					getAllValue: createGetAllValueCaller(lockupContract),
-					getPropertyValue: createGetPropertyValueCaller(lockupContract),
-					cancel: createCancelCaller(lockupContract, client),
-					withdraw: createWithdrawCaller(lockupContract, client),
-					withdrawInterest: createWithdrawInterestCaller(
-						lockupContract,
-						client
-					),
+					getValue: createGetValueCaller(contract),
+					getAllValue: createGetAllValueCaller(contract),
+					getPropertyValue: createGetPropertyValueCaller(contract),
+					cancel: createCancelCaller(contract),
+					withdraw: createWithdrawCaller(contract),
+					withdrawInterest: createWithdrawInterestCaller(contract),
 					calculateWithdrawableInterestAmount: createCalculateWithdrawableInterestAmountCaller(
-						lockupContract
+						contract
 					),
 					getStorageWithdrawalStatus: createGetStorageWithdrawalStatusCaller(
-						lockupContract
+						contract
 					),
 				}
 			}
 
-			const result = createLockupContract(client)
+			const result = createLockupContract(provider)
 
 			expect(JSON.stringify(result)).toEqual(JSON.stringify(expected))
-			expect(JSON.stringify(result())).toEqual(JSON.stringify(expected()))
+			expect(JSON.stringify(result(address))).toEqual(
+				JSON.stringify(expected(address))
+			)
 		})
 	})
 })

--- a/lib/lockup/index.ts
+++ b/lib/lockup/index.ts
@@ -1,7 +1,7 @@
-import Web3 from 'web3'
-import { Contract } from 'web3-eth-contract/types'
+import { ethers } from 'ethers'
+import { Provider } from '@ethersproject/abstract-provider'
+import { Signer } from '@ethersproject/abstract-signer'
 import { lockupAbi } from './abi'
-import { CustomOptions } from '../option'
 import { createGetValueCaller } from './getValue'
 import { createGetPropertyValueCaller } from './getPropertyValue'
 import { createCancelCaller } from './cancel'
@@ -31,29 +31,17 @@ export type LockupContract = {
 	) => Promise<string>
 }
 
-export type CreateLockupContract = (
-	client: Web3
-) => (address?: string, options?: CustomOptions) => LockupContract
-
-export const createLockupContract: CreateLockupContract = (client: Web3) => (
-	address?: string,
-	options?: CustomOptions
+export const createLockupContract = (provider: Provider | Signer) => (
+	address: string
 ): LockupContract => {
-	const contractClient: Contract = new client.eth.Contract(
-		[...lockupAbi],
-		address,
-		{
-			...options,
-		}
-	)
-
+	const contractClient = new ethers.Contract(address, [...lockupAbi], provider)
 	return {
 		getValue: createGetValueCaller(contractClient),
 		getAllValue: createGetAllValueCaller(contractClient),
 		getPropertyValue: createGetPropertyValueCaller(contractClient),
-		cancel: createCancelCaller(contractClient, client),
-		withdraw: createWithdrawCaller(contractClient, client),
-		withdrawInterest: createWithdrawInterestCaller(contractClient, client),
+		cancel: createCancelCaller(contractClient),
+		withdraw: createWithdrawCaller(contractClient),
+		withdrawInterest: createWithdrawInterestCaller(contractClient),
 		calculateWithdrawableInterestAmount: createCalculateWithdrawableInterestAmountCaller(
 			contractClient
 		),

--- a/lib/lockup/withdraw.spec.ts
+++ b/lib/lockup/withdraw.spec.ts
@@ -1,21 +1,19 @@
 import { createWithdrawCaller } from './withdraw'
-import { stubbedWeb3, stubbedSendTx } from '../utils/for-test'
+import { stubbedSendTx } from '../utils/for-test'
 
 describe('withdraw.spec.ts', () => {
 	describe('createWithdrawCaller', () => {
 		it('call success', async () => {
 			const expected = true
 			const lockupContract = {
-				methods: {
+				withdraw: jest
+					.fn()
 					// eslint-disable-next-line @typescript-eslint/no-unused-vars
-					withdraw: (property: string) => ({
-						send: jest.fn().mockImplementation(async () => stubbedSendTx()),
-					}),
-				},
+					.mockImplementation(async (property: string) => stubbedSendTx()),
 			}
 
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			const caller = createWithdrawCaller(lockupContract as any, stubbedWeb3)
+			const caller = createWithdrawCaller(lockupContract as any)
 
 			const result = await caller('0x80a25ACDD0797dfCe02dA25e4a55A4a334EE51c5')
 
@@ -23,25 +21,24 @@ describe('withdraw.spec.ts', () => {
 		})
 
 		it('call failure', async () => {
+			const error = 'error'
 			const lockupContract = {
-				methods: {
+				withdraw: jest
+					.fn()
 					// eslint-disable-next-line @typescript-eslint/no-unused-vars
-					withdraw: (property: string) => ({
-						send: jest
-							.fn()
-							.mockImplementation(async () => stubbedSendTx(undefined, true)),
-					}),
-				},
+					.mockImplementation(async (property: string) =>
+						Promise.reject(error)
+					),
 			}
 
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			const caller = createWithdrawCaller(lockupContract as any, stubbedWeb3)
+			const caller = createWithdrawCaller(lockupContract as any)
 
 			const result = await caller(
 				'0x80a25ACDD0797dfCe02dA25e4a55A4a334EE51c5'
 			).catch((err) => err)
 
-			expect(result).toBeInstanceOf(Error)
+			expect(result).toEqual(error)
 		})
 	})
 })

--- a/lib/lockup/withdraw.ts
+++ b/lib/lockup/withdraw.ts
@@ -1,21 +1,18 @@
-import { Contract } from 'web3-eth-contract/types'
-import Web3 from 'web3'
-import { execute } from '../utils/execute'
+import { ethers } from 'ethers'
+import { TransactionResponse } from '@ethersproject/abstract-provider'
+import { execute, MutationOption } from '../utils/ethers-execute'
 import { T } from 'ramda'
 
 export type CreateWithdrawCaller = (
-	contract: Contract,
-	client: Web3
+	contract: ethers.Contract
 ) => (propertyAddress: string) => Promise<boolean>
 
 export const createWithdrawCaller: CreateWithdrawCaller = (
-	contract: Contract,
-	client: Web3
+	contract: ethers.Contract
 ) => async (propertyAddress: string) =>
 	execute({
 		contract,
 		method: 'withdraw',
-		mutation: true,
-		client,
 		args: [propertyAddress],
+		mutation: true,
 	}).then(T)

--- a/lib/lockup/withdrawInterest.spec.ts
+++ b/lib/lockup/withdrawInterest.spec.ts
@@ -1,5 +1,5 @@
 import { createWithdrawInterestCaller } from './withdrawInterest'
-import { stubbedWeb3, stubbedSendTx } from '../utils/for-test'
+import { stubbedSendTx } from '../utils/for-test'
 
 describe('withdrawInterest.spec.ts', () => {
 	describe('createWithdrawInterestCaller', () => {
@@ -7,21 +7,16 @@ describe('withdrawInterest.spec.ts', () => {
 			const value = true
 
 			const lockupContract = {
-				methods: {
+				withdrawInterest: jest
+					.fn()
 					// eslint-disable-next-line @typescript-eslint/no-unused-vars
-					withdrawInterest: (property: string) => ({
-						send: jest.fn().mockImplementation(async () => stubbedSendTx()),
-					}),
-				},
+					.mockImplementation(async (property: string) => stubbedSendTx()),
 			}
 
 			const expected = value
 
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			const caller = createWithdrawInterestCaller(
-				lockupContract as any,
-				stubbedWeb3
-			)
+			const caller = createWithdrawInterestCaller(lockupContract as any)
 
 			const result = await caller('0x80a25ACDD0797dfCe02dA25e4a55A4a334EE51c5')
 
@@ -29,28 +24,24 @@ describe('withdrawInterest.spec.ts', () => {
 		})
 
 		it('call failure', async () => {
+			const error = 'error'
 			const lockupContract = {
-				methods: {
+				withdrawInterest: jest
+					.fn()
 					// eslint-disable-next-line @typescript-eslint/no-unused-vars
-					withdrawInterest: (property: string) => ({
-						send: jest
-							.fn()
-							.mockImplementation(async () => stubbedSendTx(undefined, true)),
-					}),
-				},
+					.mockImplementation(async (property: string) =>
+						Promise.reject(error)
+					),
 			}
 
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			const caller = createWithdrawInterestCaller(
-				lockupContract as any,
-				stubbedWeb3
-			)
+			const caller = createWithdrawInterestCaller(lockupContract as any)
 
 			const result = await caller(
 				'0x80a25ACDD0797dfCe02dA25e4a55A4a334EE51c5'
 			).catch((err) => err)
 
-			expect(result).toBeInstanceOf(Error)
+			expect(result).toEqual(error)
 		})
 	})
 })

--- a/lib/lockup/withdrawInterest.ts
+++ b/lib/lockup/withdrawInterest.ts
@@ -1,21 +1,17 @@
-import { Contract } from 'web3-eth-contract/types'
-import Web3 from 'web3'
-import { execute } from '../utils/execute'
+import { ethers } from 'ethers'
+import { execute, MutationOption } from '../utils/ethers-execute'
 import { T } from 'ramda'
 
 export type CreateWithdrawInterestCaller = (
-	contract: Contract,
-	client: Web3
+	contract: ethers.Contract
 ) => (propertyAddress: string) => Promise<boolean>
 
 export const createWithdrawInterestCaller: CreateWithdrawInterestCaller = (
-	contract: Contract,
-	client: Web3
+	contract: ethers.Contract
 ) => async (propertyAddress: string) =>
-	execute({
+	execute<MutationOption>({
 		contract,
 		method: 'withdrawInterest',
-		mutation: true,
-		client,
 		args: [propertyAddress],
+		mutation: true,
 	}).then(T)


### PR DESCRIPTION
Fixes #

## Proposed Changes

- I changed the provider of the RockUp API from web3 to ethers.js

```sh
~/s/g/d/dev-kit-js ❯❯❯ yarn test lib/lockup
yarn run v1.22.10
$ jest lib/lockup
 PASS  lib/lockup/getValue.spec.ts
 PASS  lib/lockup/getStorageWithdrawalStatus.spec.ts
 PASS  lib/lockup/calculateWithdrawableInterestAmount.spec.ts
 PASS  lib/lockup/getPropertyValue.spec.ts
 PASS  lib/lockup/getAllValue.spec.ts
 PASS  lib/lockup/cancel.spec.ts
 PASS  lib/lockup/withdraw.spec.ts
 PASS  lib/lockup/index.spec.ts
 PASS  lib/lockup/withdrawInterest.spec.ts

Test Suites: 9 passed, 9 total
Tests:       17 passed, 17 total
Snapshots:   0 total
Time:        6.59 s, estimated 12 s
Ran all test suites matching /lib\/lockup/i.
✨  Done in 7.84s.
```
