### PR TITLE
feat: changed the provider of the Policy, Property and Withdraw API from web3 to ethers.js

### DIFF
--- a/lib/policy-set/abi.ts
+++ b/lib/policy-set/abi.ts
@@ -1,5 +1,3 @@
-import { AbiItem } from 'web3-utils'
-
 export const policySetAbi = [
 	{
 		inputs: [
@@ -239,4 +237,4 @@ export const policySetAbi = [
 		stateMutability: 'view',
 		type: 'function',
 	},
-] as readonly AbiItem[]
+]

--- a/lib/policy-set/count.spec.ts
+++ b/lib/policy-set/count.spec.ts
@@ -6,12 +6,8 @@ describe('count.spec.ts', () => {
 			const value = '12345'
 
 			const policySetContract = {
-				methods: {
-					// eslint-disable-next-line @typescript-eslint/no-unused-vars
-					count: () => ({
-						call: jest.fn().mockImplementation(async () => value),
-					}),
-				},
+				// eslint-disable-next-line @typescript-eslint/no-unused-vars
+				count: jest.fn().mockImplementation(async () => value),
 			}
 
 			const expected = value
@@ -28,14 +24,8 @@ describe('count.spec.ts', () => {
 			const error = 'error'
 
 			const policySetContract = {
-				methods: {
-					// eslint-disable-next-line @typescript-eslint/no-unused-vars
-					count: () => ({
-						call: jest
-							.fn()
-							.mockImplementation(async () => Promise.reject(error)),
-					}),
-				},
+				// eslint-disable-next-line @typescript-eslint/no-unused-vars
+				count: jest.fn().mockImplementation(async () => Promise.reject(error)),
 			}
 
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/lib/policy-set/count.ts
+++ b/lib/policy-set/count.ts
@@ -1,13 +1,18 @@
-import { Contract } from 'web3-eth-contract/types'
-import { execute } from '../utils/execute'
+import { ethers } from 'ethers'
+import { execute, QueryOption } from '../utils/ethers-execute'
 import { always } from 'ramda'
 
-export type CreateCountCaller = (contract: Contract) => () => Promise<string>
+export type CreateCountCaller = (
+	contract: ethers.Contract
+) => () => Promise<string>
 
-export const createCountCaller: CreateCountCaller = (contract: Contract) =>
+export const createCountCaller: CreateCountCaller = (
+	contract: ethers.Contract
+) =>
 	always(
-		execute({
+		execute<QueryOption>({
 			contract,
 			method: 'count',
+			mutation: false,
 		})
 	)

--- a/lib/policy-set/get.spec.ts
+++ b/lib/policy-set/get.spec.ts
@@ -6,12 +6,8 @@ describe('get.spec.ts', () => {
 			const value = '12345'
 
 			const policySetContract = {
-				methods: {
-					// eslint-disable-next-line @typescript-eslint/no-unused-vars
-					get: (index: string) => ({
-						call: jest.fn().mockImplementation(async () => value),
-					}),
-				},
+				// eslint-disable-next-line @typescript-eslint/no-unused-vars
+				get: jest.fn().mockImplementation(async (index: string) => value),
 			}
 
 			const expected = value
@@ -28,14 +24,10 @@ describe('get.spec.ts', () => {
 			const error = 'error'
 
 			const policySetContract = {
-				methods: {
+				get: jest
+					.fn()
 					// eslint-disable-next-line @typescript-eslint/no-unused-vars
-					get: (index: string) => ({
-						call: jest
-							.fn()
-							.mockImplementation(async () => Promise.reject(error)),
-					}),
-				},
+					.mockImplementation(async (index: string) => Promise.reject(error)),
 			}
 
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/lib/policy-set/get.ts
+++ b/lib/policy-set/get.ts
@@ -1,15 +1,16 @@
-import { Contract } from 'web3-eth-contract/types'
-import { execute } from '../utils/execute'
+import { ethers } from 'ethers'
+import { execute, QueryOption } from '../utils/ethers-execute'
 
 export type CreateGetCaller = (
-	contract: Contract
+	contract: ethers.Contract
 ) => (index: string) => Promise<string>
 
-export const createGetCaller: CreateGetCaller = (contract: Contract) => async (
-	index: string
-): Promise<string> =>
-	execute({
+export const createGetCaller: CreateGetCaller = (
+	contract: ethers.Contract
+) => async (index: string): Promise<string> =>
+	execute<QueryOption>({
 		contract,
 		method: 'get',
 		args: [index],
+		mutation: false,
 	})

--- a/lib/policy-set/index.spec.ts
+++ b/lib/policy-set/index.spec.ts
@@ -1,39 +1,43 @@
-import Web3 from 'web3'
+import { ethers } from 'ethers'
 import { createPolicySetContract, PolicySetContract } from '.'
 import { createCountCaller } from './count'
 import { createGetCaller } from './get'
 import { policySetAbi } from './abi'
-import { CustomOptions } from '../option'
+
+jest.mock('./count')
+jest.mock('./get')
 
 describe('policy-set/index.ts', () => {
+	;(createCountCaller as jest.Mock).mockImplementation((contract) => contract)
+	;(createGetCaller as jest.Mock).mockImplementation((contract) => contract)
 	describe('createPolicySetContract', () => {
 		it('check return object', () => {
 			const host = 'localhost'
-			const client = new Web3()
-			client.setProvider(new Web3.providers.HttpProvider(host))
+			const address = 'address'
 
-			const expected: (
-				address?: string,
-				options?: CustomOptions
-			) => PolicySetContract = (address?: string, options?: CustomOptions) => {
-				const policySetContract = new client.eth.Contract(
-					[...policySetAbi],
+			const provider = new ethers.providers.JsonRpcProvider(host)
+
+			const expected: (address: string) => PolicySetContract = (
+				address: string
+			) => {
+				const contract = new ethers.Contract(
 					address,
-					{
-						...options,
-					}
+					[...policySetAbi],
+					provider
 				)
 
 				return {
-					count: createCountCaller(policySetContract),
-					get: createGetCaller(policySetContract),
+					count: createCountCaller(contract),
+					get: createGetCaller(contract),
 				}
 			}
 
-			const result = createPolicySetContract(client)
+			const result = createPolicySetContract(provider)
 
 			expect(JSON.stringify(result)).toEqual(JSON.stringify(expected))
-			expect(JSON.stringify(result())).toEqual(JSON.stringify(expected()))
+			expect(JSON.stringify(result(address))).toEqual(
+				JSON.stringify(expected(address))
+			)
 		})
 	})
 })

--- a/lib/policy-set/index.ts
+++ b/lib/policy-set/index.ts
@@ -1,7 +1,7 @@
-import Web3 from 'web3'
-import { Contract } from 'web3-eth-contract/types'
+import { ethers } from 'ethers'
+import { Provider } from '@ethersproject/abstract-provider'
+import { Signer } from '@ethersproject/abstract-signer'
 import { policySetAbi } from './abi'
-import { CustomOptions } from '../option'
 import { createCountCaller } from './count'
 import { createGetCaller } from './get'
 
@@ -10,19 +10,13 @@ export type PolicySetContract = {
 	readonly get: (index: string) => Promise<string>
 }
 
-export type CreatePolicySetContract = (
-	client: Web3
-) => (address?: string, options?: CustomOptions) => PolicySetContract
-
-export const createPolicySetContract: CreatePolicySetContract = (
-	client: Web3
-) => (address?: string, options?: CustomOptions) => {
-	const contractClient: Contract = new client.eth.Contract(
-		[...policySetAbi],
+export const createPolicySetContract = (provider: Provider | Signer) => (
+	address: string
+): PolicySetContract => {
+	const contractClient = new ethers.Contract(
 		address,
-		{
-			...options,
-		}
+		[...policySetAbi],
+		provider
 	)
 
 	return {

--- a/lib/policy/abi.ts
+++ b/lib/policy/abi.ts
@@ -1,5 +1,3 @@
-import { AbiItem } from 'web3-utils'
-
 export const policyAbi = [
 	{
 		inputs: [
@@ -314,4 +312,4 @@ export const policyAbi = [
 		stateMutability: 'nonpayable',
 		type: 'function',
 	},
-] as readonly AbiItem[]
+]

--- a/lib/policy/holdersShare.spec.ts
+++ b/lib/policy/holdersShare.spec.ts
@@ -6,12 +6,10 @@ describe('holdersShare.spec.ts', () => {
 			const value = '12345'
 
 			const policyContract = {
-				methods: {
+				holdersShare: jest
+					.fn()
 					// eslint-disable-next-line @typescript-eslint/no-unused-vars
-					holdersShare: (amount: string, lockups: string) => ({
-						call: jest.fn().mockImplementation(async () => value),
-					}),
-				},
+					.mockImplementation(async (amount: string, lockups: string) => value),
 			}
 
 			const expected = value
@@ -28,14 +26,12 @@ describe('holdersShare.spec.ts', () => {
 			const error = 'error'
 
 			const policyContract = {
-				methods: {
+				holdersShare: jest
+					.fn()
 					// eslint-disable-next-line @typescript-eslint/no-unused-vars
-					holdersShare: (amount: string, lockups: string) => ({
-						call: jest
-							.fn()
-							.mockImplementation(async () => Promise.reject(error)),
-					}),
-				},
+					.mockImplementation(async (amount: string, lockups: string) =>
+						Promise.reject(error)
+					),
 			}
 
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/lib/policy/holdersShare.ts
+++ b/lib/policy/holdersShare.ts
@@ -1,15 +1,16 @@
-import { Contract } from 'web3-eth-contract/types'
-import { execute } from '../utils/execute'
+import { ethers } from 'ethers'
+import { execute, QueryOption } from '../utils/ethers-execute'
 
 export type CreateHoldersShareCaller = (
-	contract: Contract
+	contract: ethers.Contract
 ) => (amount: string, lockups: string) => Promise<string>
 
 export const createHoldersShareCaller: CreateHoldersShareCaller = (
-	contract: Contract
+	contract: ethers.Contract
 ) => async (amount: string, lockups: string): Promise<string> =>
-	execute({
+	execute<QueryOption>({
 		contract,
 		method: 'holdersShare',
 		args: [amount, lockups],
+		mutation: false,
 	})

--- a/lib/policy/index.ts
+++ b/lib/policy/index.ts
@@ -1,29 +1,17 @@
-import Web3 from 'web3'
-import { Contract } from 'web3-eth-contract/types'
+import { ethers } from 'ethers'
+import { Provider } from '@ethersproject/abstract-provider'
+import { Signer } from '@ethersproject/abstract-signer'
 import { policyAbi } from './abi'
-import { CustomOptions } from '../option'
 import { createHoldersShareCaller } from './holdersShare'
 
 export type PolicyContract = {
 	readonly holdersShare: (amount: string, lockups: string) => Promise<string>
 }
 
-export type CreatePolicyContract = (
-	client: Web3
-) => (address?: string, options?: CustomOptions) => PolicyContract
-
-export const createPolicyContract: CreatePolicyContract = (client: Web3) => (
-	address?: string,
-	options?: CustomOptions
-) => {
-	const contractClient: Contract = new client.eth.Contract(
-		[...policyAbi],
-		address,
-		{
-			...options,
-		}
-	)
-
+export const createPolicyContract = (provider: Provider | Signer) => (
+	address: string
+): PolicyContract => {
+	const contractClient = new ethers.Contract(address, [...policyAbi], provider)
 	return {
 		holdersShare: createHoldersShareCaller(contractClient),
 	}

--- a/lib/property/abi.ts
+++ b/lib/property/abi.ts
@@ -1,6 +1,4 @@
-import { AbiItem } from 'web3-utils'
-
-export const propertyAbi = ([
+export const propertyAbi = [
 	{
 		inputs: [
 			{
@@ -370,4 +368,4 @@ export const propertyAbi = ([
 		stateMutability: 'nonpayable',
 		type: 'function',
 	},
-] as unknown) as readonly AbiItem[]
+]

--- a/lib/property/index.spec.ts
+++ b/lib/property/index.spec.ts
@@ -1,38 +1,44 @@
-import Web3 from 'web3'
+import { ethers } from 'ethers'
 import { createPropertyContract, PropertyContract } from '.'
 import { createOwnerCaller } from './owner'
 import { createTransferCaller } from './transfer'
 import { propertyAbi } from './abi'
-import { CustomOptions } from '../option'
+
+jest.mock('./owner')
+jest.mock('./transfer')
 
 describe('property/index.ts', () => {
+	;(createOwnerCaller as jest.Mock).mockImplementation((contract) => contract)
+	;(createTransferCaller as jest.Mock).mockImplementation(
+		(contract) => contract
+	)
 	describe('createPropertyContract', () => {
 		it('check return object', () => {
 			const host = 'localhost'
-			const client = new Web3()
-			client.setProvider(new Web3.providers.HttpProvider(host))
+			const address = 'address'
 
-			const expected: (
-				address?: string,
-				options?: CustomOptions
-			) => PropertyContract = (address?: string, options?: CustomOptions) => {
-				const propertyContract = new client.eth.Contract(
-					[...propertyAbi],
+			const provider = new ethers.providers.JsonRpcProvider(host)
+
+			const expected: (address: string) => PropertyContract = (
+				address: string
+			) => {
+				const contract = new ethers.Contract(
 					address,
-					{
-						...options,
-					}
+					[...propertyAbi],
+					provider
 				)
 				return {
-					owner: createOwnerCaller(propertyContract),
-					transfer: createTransferCaller(propertyContract, client),
+					owner: createOwnerCaller(contract),
+					transfer: createTransferCaller(contract),
 				}
 			}
 
-			const result = createPropertyContract(client)
+			const result = createPropertyContract(provider)
 
 			expect(JSON.stringify(result)).toEqual(JSON.stringify(expected))
-			expect(JSON.stringify(result())).toEqual(JSON.stringify(expected()))
+			expect(JSON.stringify(result(address))).toEqual(
+				JSON.stringify(expected(address))
+			)
 		})
 	})
 })

--- a/lib/property/index.ts
+++ b/lib/property/index.ts
@@ -1,7 +1,7 @@
-import Web3 from 'web3'
-import { Contract } from 'web3-eth-contract/types'
+import { ethers } from 'ethers'
+import { Provider } from '@ethersproject/abstract-provider'
+import { Signer } from '@ethersproject/abstract-signer'
 import { propertyAbi } from './abi'
-import { CustomOptions } from '../option'
 import { createOwnerCaller } from './owner'
 import { createTransferCaller } from './transfer'
 
@@ -10,23 +10,17 @@ export type PropertyContract = {
 	readonly transfer: (to: string, value: string) => Promise<boolean>
 }
 
-export type CreatePropertyContract = (
-	client: Web3
-) => (address?: string, options?: CustomOptions) => PropertyContract
-
-export const createPropertyContract: CreatePropertyContract = (
-	client: Web3
-) => (address?: string, options?: CustomOptions): PropertyContract => {
-	const contractClient: Contract = new client.eth.Contract(
-		[...propertyAbi],
+export const createPropertyContract = (provider: Provider | Signer) => (
+	address: string
+): PropertyContract => {
+	const contractClient = new ethers.Contract(
 		address,
-		{
-			...options,
-		}
+		[...propertyAbi],
+		provider
 	)
 
 	return {
 		owner: createOwnerCaller(contractClient),
-		transfer: createTransferCaller(contractClient, client),
+		transfer: createTransferCaller(contractClient),
 	}
 }

--- a/lib/property/owner.spec.ts
+++ b/lib/property/owner.spec.ts
@@ -6,13 +6,7 @@ describe('owner.spec.ts', () => {
 			const value = 'value'
 
 			const propertyContract = {
-				methods: {
-					owner: () => ({
-						call: jest
-							.fn()
-							.mockImplementation(async () => Promise.resolve(value)),
-					}),
-				},
+				owner: jest.fn().mockImplementation(async () => Promise.resolve(value)),
 			}
 
 			const expected = value
@@ -29,13 +23,7 @@ describe('owner.spec.ts', () => {
 			const error = 'error'
 
 			const propertyContract = {
-				methods: {
-					owner: () => ({
-						call: jest
-							.fn()
-							.mockImplementation(async () => Promise.reject(error)),
-					}),
-				},
+				owner: jest.fn().mockImplementation(async () => Promise.reject(error)),
 			}
 
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/lib/property/owner.ts
+++ b/lib/property/owner.ts
@@ -1,8 +1,18 @@
-import { Contract } from 'web3-eth-contract/types'
-import { execute } from '../utils/execute'
+import { ethers } from 'ethers'
+import { execute, QueryOption } from '../utils/ethers-execute'
 import { always } from 'ramda'
 
-export type CreateOwnerCaller = (contract: Contract) => () => Promise<string>
+export type CreateOwnerCaller = (
+	contract: ethers.Contract
+) => () => Promise<string>
 
-export const createOwnerCaller: CreateOwnerCaller = (contract: Contract) =>
-	always(execute({ contract, method: 'owner' }))
+export const createOwnerCaller: CreateOwnerCaller = (
+	contract: ethers.Contract
+) =>
+	always(
+		execute<QueryOption>({
+			contract,
+			method: 'owner',
+			mutation: false,
+		})
+	)

--- a/lib/property/transfer.spec.ts
+++ b/lib/property/transfer.spec.ts
@@ -9,18 +9,18 @@ describe('transfer.spec.ts', () => {
 			const value = '12345'
 
 			const propertyContract = {
-				methods: {
+				transfer: jest
+					.fn()
 					// eslint-disable-next-line @typescript-eslint/no-unused-vars
-					transfer: (to: string, value: number) => ({
-						send: jest.fn().mockImplementation(async () => stubbedSendTx()),
-					}),
-				},
+					.mockImplementation(async (to: string, value: number) =>
+						stubbedSendTx()
+					),
 			}
 
 			const expected = success
 
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			const caller = createTransferCaller(propertyContract as any, stubbedWeb3)
+			const caller = createTransferCaller(propertyContract as any)
 
 			const result = await caller(to, value)
 
@@ -28,26 +28,25 @@ describe('transfer.spec.ts', () => {
 		})
 
 		it('call failure', async () => {
+			const error = 'error'
 			const to = '0x0472ec0185ebb8202f3d4ddb0226998889663cf2'
 			const value = '12345'
 
 			const propertyContract = {
-				methods: {
+				transfer: jest
+					.fn()
 					// eslint-disable-next-line @typescript-eslint/no-unused-vars
-					transfer: (to: string, value: number) => ({
-						send: jest
-							.fn()
-							.mockImplementation(async () => stubbedSendTx(undefined, true)),
-					}),
-				},
+					.mockImplementation(async (to: string, value: number) =>
+						Promise.reject(error)
+					),
 			}
 
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			const caller = createTransferCaller(propertyContract as any, stubbedWeb3)
+			const caller = createTransferCaller(propertyContract as any)
 
 			const result = await caller(to, value).catch((err) => err)
 
-			expect(result).toBeInstanceOf(Error)
+			expect(result).toEqual(error)
 		})
 	})
 })

--- a/lib/property/transfer.ts
+++ b/lib/property/transfer.ts
@@ -1,21 +1,17 @@
-import { Contract } from 'web3-eth-contract/types'
-import Web3 from 'web3'
-import { execute } from '../utils/execute'
+import { ethers } from 'ethers'
+import { execute, MutationOption } from '../utils/ethers-execute'
 import { T } from 'ramda'
 
 export type CreateTransferCaller = (
-	contract: Contract,
-	client: Web3
+	contract: ethers.Contract
 ) => (to: string, value: string) => Promise<boolean>
 
 export const createTransferCaller: CreateTransferCaller = (
-	contract: Contract,
-	client: Web3
+	contract: ethers.Contract
 ) => async (to: string, value: string) =>
-	execute({
+	execute<MutationOption>({
 		contract,
 		method: 'transfer',
-		mutation: true,
-		client,
 		args: [to, value],
+		mutation: true,
 	}).then(T)

--- a/lib/withdraw/abi.ts
+++ b/lib/withdraw/abi.ts
@@ -1,6 +1,4 @@
-import { AbiItem } from 'web3-utils'
-
-export const withdrawAbi = ([
+export const withdrawAbi = [
 	{
 		inputs: [
 			{
@@ -315,4 +313,4 @@ export const withdrawAbi = ([
 		stateMutability: 'view',
 		type: 'function',
 	},
-] as unknown) as readonly AbiItem[]
+]

--- a/lib/withdraw/calculateWithdrawableAmount.spec.ts
+++ b/lib/withdraw/calculateWithdrawableAmount.spec.ts
@@ -6,14 +6,12 @@ describe('calculateWithdrawableAmount.spec.ts', () => {
 			const value = 'value'
 
 			const withdrawContract = {
-				methods: {
+				calculateWithdrawableAmount: jest
+					.fn()
 					// eslint-disable-next-line @typescript-eslint/no-unused-vars
-					calculateWithdrawableAmount: (address: string) => ({
-						call: jest
-							.fn()
-							.mockImplementation(async () => Promise.resolve(value)),
-					}),
-				},
+					.mockImplementation(async (address: string) =>
+						Promise.resolve(value)
+					),
 			}
 
 			const expected = value
@@ -35,14 +33,10 @@ describe('calculateWithdrawableAmount.spec.ts', () => {
 			const error = 'error'
 
 			const withdrawContract = {
-				methods: {
+				calculateWithdrawableAmount: jest
+					.fn()
 					// eslint-disable-next-line @typescript-eslint/no-unused-vars
-					calculateWithdrawableAmount: (address: string) => ({
-						call: jest
-							.fn()
-							.mockImplementation(async () => Promise.reject(error)),
-					}),
-				},
+					.mockImplementation(async (address: string) => Promise.reject(error)),
 			}
 
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/lib/withdraw/calculateWithdrawableAmount.ts
+++ b/lib/withdraw/calculateWithdrawableAmount.ts
@@ -1,15 +1,16 @@
-import { Contract } from 'web3-eth-contract/types'
-import { execute } from '../utils/execute'
+import { ethers } from 'ethers'
+import { execute, QueryOption } from '../utils/ethers-execute'
 
 export type CreateCalculateWithdrawableAmountCaller = (
-	contract: Contract
+	contract: ethers.Contract
 ) => (propertyAddress: string, accountAddress: string) => Promise<string>
 
 export const createCalculateWithdrawableAmountCaller: CreateCalculateWithdrawableAmountCaller = (
-	contract: Contract
+	contract: ethers.Contract
 ) => async (propertyAddress: string, accountAddress: string) =>
-	execute({
+	execute<QueryOption>({
 		contract,
 		method: 'calculateWithdrawableAmount',
 		args: [propertyAddress, accountAddress],
+		mutation: false,
 	})

--- a/lib/withdraw/getRewardsAmount.spec.ts
+++ b/lib/withdraw/getRewardsAmount.spec.ts
@@ -6,14 +6,12 @@ describe('getRewardsAmount.spec.ts', () => {
 			const value = 'value'
 
 			const withdrawContract = {
-				methods: {
+				getRewardsAmount: jest
+					.fn()
 					// eslint-disable-next-line @typescript-eslint/no-unused-vars
-					getRewardsAmount: (address: string) => ({
-						call: jest
-							.fn()
-							.mockImplementation(async () => Promise.resolve(value)),
-					}),
-				},
+					.mockImplementation(async (address: string) =>
+						Promise.resolve(value)
+					),
 			}
 
 			const expected = value
@@ -30,14 +28,10 @@ describe('getRewardsAmount.spec.ts', () => {
 			const error = 'error'
 
 			const withdrawContract = {
-				methods: {
+				getRewardsAmount: jest
+					.fn()
 					// eslint-disable-next-line @typescript-eslint/no-unused-vars
-					getRewardsAmount: (address: string) => ({
-						call: jest
-							.fn()
-							.mockImplementation(async () => Promise.reject(error)),
-					}),
-				},
+					.mockImplementation(async (address: string) => Promise.reject(error)),
 			}
 
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/lib/withdraw/getRewardsAmount.ts
+++ b/lib/withdraw/getRewardsAmount.ts
@@ -1,11 +1,16 @@
-import { Contract } from 'web3-eth-contract/types'
-import { execute } from '../utils/execute'
+import { ethers } from 'ethers'
+import { execute, QueryOption } from '../utils/ethers-execute'
 
 export type CreateGetRewardsAmountCaller = (
-	contract: Contract
+	contract: ethers.Contract
 ) => (address: string) => Promise<string>
 
 export const createGetRewardsAmountCaller: CreateGetRewardsAmountCaller = (
-	contract: Contract
+	contract: ethers.Contract
 ) => async (address: string) =>
-	execute({ contract, method: 'getRewardsAmount', args: [address] })
+	execute<QueryOption>({
+		contract,
+		method: 'getRewardsAmount',
+		args: [address],
+		mutation: false,
+	})

--- a/lib/withdraw/index.ts
+++ b/lib/withdraw/index.ts
@@ -1,7 +1,7 @@
-import Web3 from 'web3'
-import { Contract } from 'web3-eth-contract/types'
+import { ethers } from 'ethers'
+import { Provider } from '@ethersproject/abstract-provider'
+import { Signer } from '@ethersproject/abstract-signer'
 import { withdrawAbi } from './abi'
-import { CustomOptions } from '../option'
 import { createWithdrawCaller } from './withdraw'
 import { createGetRewardsAmountCaller } from './getRewardsAmount'
 import { createCalculateWithdrawableAmountCaller } from './calculateWithdrawableAmount'
@@ -15,23 +15,17 @@ export type WithdrawContract = {
 	) => Promise<string>
 }
 
-export type CreateWithdrawContract = (
-	client: Web3
-) => (address?: string, options?: CustomOptions) => WithdrawContract
-
-export const createWithdrawContract: CreateWithdrawContract = (
-	client: Web3
-) => (address?: string, options?: CustomOptions): WithdrawContract => {
-	const contractClient: Contract = new client.eth.Contract(
-		[...withdrawAbi],
+export const createWithdrawContract = (provider: Provider | Signer) => (
+	address: string
+): WithdrawContract => {
+	const contractClient = new ethers.Contract(
 		address,
-		{
-			...options,
-		}
+		[...withdrawAbi],
+		provider
 	)
 
 	return {
-		withdraw: createWithdrawCaller(contractClient, client),
+		withdraw: createWithdrawCaller(contractClient),
 		getRewardsAmount: createGetRewardsAmountCaller(contractClient),
 		calculateWithdrawableAmount: createCalculateWithdrawableAmountCaller(
 			contractClient

--- a/lib/withdraw/withdraw.spec.ts
+++ b/lib/withdraw/withdraw.spec.ts
@@ -7,18 +7,16 @@ describe('withdraw.spec.ts', () => {
 			const value = true
 
 			const withdrawContract = {
-				methods: {
+				withdraw: jest
+					.fn()
 					// eslint-disable-next-line @typescript-eslint/no-unused-vars
-					withdraw: (property: string) => ({
-						send: jest.fn().mockImplementation(async () => stubbedSendTx()),
-					}),
-				},
+					.mockImplementation(async (property: string) => stubbedSendTx()),
 			}
 
 			const expected = value
 
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			const caller = createWithdrawCaller(withdrawContract as any, stubbedWeb3)
+			const caller = createWithdrawCaller(withdrawContract as any)
 
 			const result = await caller('0x80a25ACDD0797dfCe02dA25e4a55A4a334EE51c5')
 
@@ -26,25 +24,24 @@ describe('withdraw.spec.ts', () => {
 		})
 
 		it('call failure', async () => {
+			const error = 'error'
 			const withdrawContract = {
-				methods: {
+				withdraw: jest
+					.fn()
 					// eslint-disable-next-line @typescript-eslint/no-unused-vars
-					withdraw: (property: string) => ({
-						send: jest
-							.fn()
-							.mockImplementation(async () => stubbedSendTx(undefined, true)),
-					}),
-				},
+					.mockImplementation(async (property: string) =>
+						Promise.reject(error)
+					),
 			}
 
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			const caller = createWithdrawCaller(withdrawContract as any, stubbedWeb3)
+			const caller = createWithdrawCaller(withdrawContract as any)
 
 			const result = await caller(
 				'0x80a25ACDD0797dfCe02dA25e4a55A4a334EE51c5'
 			).catch((err) => err)
 
-			expect(result).toBeInstanceOf(Error)
+			expect(result).toEqual(error)
 		})
 	})
 })

--- a/lib/withdraw/withdraw.ts
+++ b/lib/withdraw/withdraw.ts
@@ -1,22 +1,17 @@
-import { Contract } from 'web3-eth-contract/types'
-import Web3 from 'web3'
-import { getAccount } from '../utils/getAccount'
-import { execute } from '../utils/execute'
+import { ethers } from 'ethers'
+import { execute, MutationOption } from '../utils/ethers-execute'
 import { T } from 'ramda'
 
 export type CreateWithdrawCaller = (
-	contract: Contract,
-	client: Web3
+	contract: ethers.Contract
 ) => (propertyAddress: string) => Promise<boolean>
 
 export const createWithdrawCaller: CreateWithdrawCaller = (
-	contract: Contract,
-	client: Web3
+	contract: ethers.Contract
 ) => async (propertyAddress) =>
-	execute({
+	execute<MutationOption>({
 		contract,
 		method: 'withdraw',
 		mutation: true,
-		client,
 		args: [propertyAddress],
 	}).then(T)


### PR DESCRIPTION
Fixes #

## Proposed Changes

- I changed the provider of the Policy, Property and Withdraw API from web3 to ethers.js

```sh
~/s/g/d/dev-kit-js ❯❯❯ yarn test lib/withdraw lib/property lib/policy
yarn run v1.22.10
$ jest lib/withdraw lib/property lib/policy
 PASS  lib/property/owner.spec.ts
 PASS  lib/property-factory/create.spec.ts
 PASS  lib/property/transfer.spec.ts
 PASS  lib/withdraw/index.spec.ts
 PASS  lib/property/index.spec.ts
 PASS  lib/property-factory/index.spec.ts
 PASS  lib/withdraw/withdraw.spec.ts
 PASS  lib/policy-set/count.spec.ts
 PASS  lib/policy-set/get.spec.ts
 PASS  lib/withdraw/calculateWithdrawableAmount.spec.ts
 PASS  lib/withdraw/getRewardsAmount.spec.ts
 PASS  lib/policy-set/index.spec.ts
 PASS  lib/policy/holdersShare.spec.ts
 PASS  lib/policy/index.spec.ts

Test Suites: 14 passed, 14 total
Tests:       23 passed, 23 total
Snapshots:   0 total
Time:        6.678 s, estimated 11 s
Ran all test suites matching /lib\/withdraw|lib\/property|lib\/policy/i.
✨  Done in 7.76s.
```