### PR TITLE
feat: changed the provider of the withdraw API from web3 to ethers.js

### DIFF
--- a/lib/utils/for-test.ts
+++ b/lib/utils/for-test.ts
@@ -14,7 +14,6 @@ import {
 	TransactionResponse,
 	TransactionReceipt,
 } from '@ethersproject/abstract-provider'
-import { SendTx } from './web3-txs'
 import { BigNumber } from 'ethers'
 
 export const stubbedWeb3 = {
@@ -91,7 +90,7 @@ export const stubbedSendTx = (
 	},
 	reject = false,
 	rejectOnConfirmation = false
-): SendTx => {
+) => {
 	const result = {
 		status: true,
 		events: {

--- a/lib/withdraw/abi.ts
+++ b/lib/withdraw/abi.ts
@@ -1,5 +1,3 @@
-import { AbiItem } from 'web3-utils'
-
 export const withdrawAbi = [
 	{
 		inputs: [
@@ -453,4 +451,4 @@ export const withdrawAbi = [
 		stateMutability: 'view',
 		type: 'function',
 	},
-] as readonly AbiItem[]
+]

--- a/lib/withdraw/bulkWithdraw.ts
+++ b/lib/withdraw/bulkWithdraw.ts
@@ -1,21 +1,17 @@
-/* eslint-disable @typescript-eslint/prefer-readonly-parameter-types */
-import { Contract } from 'web3-eth-contract/types'
-import Web3 from 'web3'
-import { execute } from '../utils/execute'
-import { TxReceipt } from '../utils/web3-txs'
+import { ethers } from 'ethers'
+import { execute, MutationOption } from '../utils/execute'
+import { TransactionResponse } from '@ethersproject/abstract-provider'
 
 export type CreateBulkWithdrawCaller = (
-	contract: Contract,
-	client: Web3
-) => (propertyAddresses: readonly string[]) => Promise<TxReceipt>
+	contract: ethers.Contract
+) => (propertyAddresses: readonly string[]) => Promise<TransactionResponse>
 
 export const createBulkWithdrawCaller: CreateBulkWithdrawCaller =
-	(contract: Contract, client: Web3) =>
-	async (propertyAddresses): Promise<TxReceipt> =>
-		execute({
+	(contract: ethers.Contract) =>
+	async (propertyAddresses): Promise<TransactionResponse> =>
+		execute<MutationOption>({
 			contract,
 			method: 'bulkWithdraw',
 			mutation: true,
-			client,
-			args: [propertyAddresses],
+			args: propertyAddresses,
 		})

--- a/lib/withdraw/calculateRewardAmount.spec.ts
+++ b/lib/withdraw/calculateRewardAmount.spec.ts
@@ -6,14 +6,12 @@ describe('calculateRewardAmount.spec.ts', () => {
 			const value = ['value1', 'value2', 'value3', 'value4']
 
 			const rewardContract = {
-				methods: {
+				calculateRewardAmount: jest
+					.fn()
 					// eslint-disable-next-line @typescript-eslint/no-unused-vars
-					calculateRewardAmount: (address: string) => ({
-						call: jest
-							.fn()
-							.mockImplementation(async () => Promise.resolve(value)),
-					}),
-				},
+					.mockImplementation(async (address: string) =>
+						Promise.resolve(value)
+					),
 			}
 
 			const expected = value
@@ -33,14 +31,10 @@ describe('calculateRewardAmount.spec.ts', () => {
 			const error = 'error'
 
 			const rewardContract = {
-				methods: {
+				calculateRewardAmount: jest
+					.fn()
 					// eslint-disable-next-line @typescript-eslint/no-unused-vars
-					calculateRewardAmount: (address: string) => ({
-						call: jest
-							.fn()
-							.mockImplementation(async () => Promise.reject(error)),
-					}),
-				},
+					.mockImplementation(async (address: string) => Promise.reject(error)),
 			}
 
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/lib/withdraw/calculateRewardAmount.ts
+++ b/lib/withdraw/calculateRewardAmount.ts
@@ -1,20 +1,20 @@
-/* eslint-disable @typescript-eslint/prefer-readonly-parameter-types */
-import { Contract } from 'web3-eth-contract'
-import { arrayify } from '../utils/arrayify'
-import { execute } from '../utils/execute'
+import { ethers } from 'ethers'
+import { execute, QueryOption } from '../utils/execute'
+
 
 export type calculateRewardAmountCaller = (
-	contract: Contract
+	contract: ethers.Contract
 ) => (
 	propertyAddress: string,
 	accountAddress: string
-) => Promise<readonly [string, string, string, string]>
+) => Promise<string>
 
 export const calculateRewardAmountCaller: calculateRewardAmountCaller =
-	(contract: Contract) =>
+	(contract: ethers.Contract) =>
 	async (propertyAddress: string, accountAddress: string) =>
-		execute<Record<string, string>>({
+		execute<QueryOption>({
 			contract,
 			method: 'calculateRewardAmount',
 			args: [propertyAddress, accountAddress],
-		}).then((r) => arrayify(r) as readonly [string, string, string, string])
+			mutation: false
+		})

--- a/lib/withdraw/calculateWithdrawableAmount.spec.ts
+++ b/lib/withdraw/calculateWithdrawableAmount.spec.ts
@@ -6,14 +6,12 @@ describe('calculateWithdrawableAmount.spec.ts', () => {
 			const value = 'value'
 
 			const withdrawContract = {
-				methods: {
+				calculateWithdrawableAmount: jest
+					.fn()
 					// eslint-disable-next-line @typescript-eslint/no-unused-vars
-					calculateWithdrawableAmount: (address: string) => ({
-						call: jest
-							.fn()
-							.mockImplementation(async () => Promise.resolve(value)),
-					}),
-				},
+					.mockImplementation(async (address: string) =>
+						Promise.resolve(value)
+					),
 			}
 
 			const expected = value
@@ -35,14 +33,10 @@ describe('calculateWithdrawableAmount.spec.ts', () => {
 			const error = 'error'
 
 			const withdrawContract = {
-				methods: {
+				calculateWithdrawableAmount: jest
+					.fn()
 					// eslint-disable-next-line @typescript-eslint/no-unused-vars
-					calculateWithdrawableAmount: (address: string) => ({
-						call: jest
-							.fn()
-							.mockImplementation(async () => Promise.reject(error)),
-					}),
-				},
+					.mockImplementation(async (address: string) => Promise.reject(error)),
 			}
 
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/lib/withdraw/calculateWithdrawableAmount.ts
+++ b/lib/withdraw/calculateWithdrawableAmount.ts
@@ -1,17 +1,17 @@
-/* eslint-disable @typescript-eslint/prefer-readonly-parameter-types */
-import { Contract } from 'web3-eth-contract/types'
-import { execute } from '../utils/execute'
+import { ethers } from 'ethers'
+import { execute, QueryOption } from '../utils/execute'
 
 export type CreateCalculateWithdrawableAmountCaller = (
-	contract: Contract
+	contract: ethers.Contract
 ) => (propertyAddress: string, accountAddress: string) => Promise<string>
 
 export const createCalculateWithdrawableAmountCaller: CreateCalculateWithdrawableAmountCaller =
 
-		(contract: Contract) =>
+		(contract: ethers.Contract) =>
 		async (propertyAddress: string, accountAddress: string) =>
-			execute({
+			execute<QueryOption>({
 				contract,
 				method: 'calculateWithdrawableAmount',
 				args: [propertyAddress, accountAddress],
+				mutation: false
 			})

--- a/lib/withdraw/getRewardsAmount.spec.ts
+++ b/lib/withdraw/getRewardsAmount.spec.ts
@@ -6,14 +6,12 @@ describe('getRewardsAmount.spec.ts', () => {
 			const value = 'value'
 
 			const withdrawContract = {
-				methods: {
+				getRewardsAmount: jest
+					.fn()
 					// eslint-disable-next-line @typescript-eslint/no-unused-vars
-					getRewardsAmount: (address: string) => ({
-						call: jest
-							.fn()
-							.mockImplementation(async () => Promise.resolve(value)),
-					}),
-				},
+					.mockImplementation(async (address: string) =>
+						Promise.resolve(value)
+					),
 			}
 
 			const expected = value
@@ -30,14 +28,10 @@ describe('getRewardsAmount.spec.ts', () => {
 			const error = 'error'
 
 			const withdrawContract = {
-				methods: {
+				getRewardsAmount: jest
+					.fn()
 					// eslint-disable-next-line @typescript-eslint/no-unused-vars
-					getRewardsAmount: (address: string) => ({
-						call: jest
-							.fn()
-							.mockImplementation(async () => Promise.reject(error)),
-					}),
-				},
+					.mockImplementation(async (address: string) => Promise.reject(error)),
 			}
 
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/lib/withdraw/getRewardsAmount.ts
+++ b/lib/withdraw/getRewardsAmount.ts
@@ -1,11 +1,15 @@
-/* eslint-disable @typescript-eslint/prefer-readonly-parameter-types */
-import { Contract } from 'web3-eth-contract/types'
-import { execute } from '../utils/execute'
+import { ethers } from 'ethers'
+import { execute, QueryOption } from '../utils/execute'
 
 export type CreateGetRewardsAmountCaller = (
-	contract: Contract
+	contract: ethers.Contract
 ) => (address: string) => Promise<string>
 
 export const createGetRewardsAmountCaller: CreateGetRewardsAmountCaller =
-	(contract: Contract) => async (address: string) =>
-		execute({ contract, method: 'getRewardsAmount', args: [address] })
+	(contract: ethers.Contract) => async (address: string) =>
+		execute<QueryOption>({
+			contract,
+			method: 'getRewardsAmount',
+			args: [address],
+			mutation: false,
+		})

--- a/lib/withdraw/index.spec.ts
+++ b/lib/withdraw/index.spec.ts
@@ -1,49 +1,63 @@
-import Web3 from 'web3'
+import { ethers } from 'ethers'
 import { createWithdrawContract, WithdrawContract } from '.'
 import { withdrawAbi } from './abi'
-import { CustomOptions } from '../option'
 import { createWithdrawCaller } from './withdraw'
 import { createBulkWithdrawCaller } from './bulkWithdraw'
 import { createGetRewardsAmountCaller } from './getRewardsAmount'
 import { createCalculateWithdrawableAmountCaller } from './calculateWithdrawableAmount'
 import { calculateRewardAmountCaller } from './calculateRewardAmount'
 
+jest.mock('./withdraw')
+jest.mock('./bulkWithdraw')
+jest.mock('./getRewardsAmount')
+jest.mock('./calculateWithdrawableAmount')
+jest.mock('./calculateRewardAmount')
+
 describe('lockup/index.ts', () => {
+	;(createWithdrawCaller as jest.Mock).mockImplementation(
+		(contract) => contract
+	)
+	;(createBulkWithdrawCaller as jest.Mock).mockImplementation(
+		(contract) => contract
+	)
+	;(createGetRewardsAmountCaller as jest.Mock).mockImplementation(
+		(contract) => contract
+	)
+	;(createCalculateWithdrawableAmountCaller as jest.Mock).mockImplementation(
+		(contract) => contract
+	)
+	;(calculateRewardAmountCaller as jest.Mock).mockImplementation(
+		(contract) => contract
+	)
 	describe('createLockupContract', () => {
 		it('check return object', () => {
 			const host = 'localhost'
-			const client = new Web3()
-			client.setProvider(new Web3.providers.HttpProvider(host))
+			const address = '0x0000000000000000000000000000000000000000'
+			const provider = new ethers.providers.JsonRpcProvider(host)
 
-			const expected: (
-				address?: string,
-				options?: CustomOptions
-			) => WithdrawContract = (address?: string, options?: CustomOptions) => {
-				const withdrawContract = new client.eth.Contract(
-					[...withdrawAbi],
+			const expected: (address: string) => WithdrawContract = (
+				address: string
+			) => {
+				const contract = new ethers.Contract(
 					address,
-					{
-						...options,
-					}
+					[...withdrawAbi],
+					provider
 				)
 				return {
-					withdraw: createWithdrawCaller(withdrawContract, client),
-					bulkWithdraw: createBulkWithdrawCaller(withdrawContract, client),
-					getRewardsAmount: createGetRewardsAmountCaller(withdrawContract),
+					withdraw: createWithdrawCaller(contract),
+					bulkWithdraw: createBulkWithdrawCaller(contract),
+					getRewardsAmount: createGetRewardsAmountCaller(contract),
 					calculateWithdrawableAmount:
-						createCalculateWithdrawableAmountCaller(withdrawContract),
-					calculateRewardAmount: calculateRewardAmountCaller(withdrawContract),
-					contract: () => withdrawContract,
+						createCalculateWithdrawableAmountCaller(contract),
+					calculateRewardAmount: calculateRewardAmountCaller(contract),
 				}
 			}
 
-			const result = createWithdrawContract(client)
+			const result = createWithdrawContract(provider)
 
 			expect(JSON.stringify(result)).toEqual(JSON.stringify(expected))
-			expect(
-				JSON.stringify(result('0x0000000000000000000000000000000000000000'))
-			).toEqual(
-				JSON.stringify(expected('0x0000000000000000000000000000000000000000'))
+			expect(JSON.stringify(result(address))).toEqual(
+				JSON.stringify(expected(address))
 			)
 		})
 	})

--- a/lib/withdraw/withdraw.spec.ts
+++ b/lib/withdraw/withdraw.spec.ts
@@ -1,5 +1,5 @@
 import { createWithdrawCaller } from './withdraw'
-import { stubbedWeb3, stubbedSendTx } from '../utils/for-test'
+import { stubbedSendTx } from '../utils/for-test'
 
 describe('withdraw.spec.ts', () => {
 	describe('createwithdrawCaller', () => {
@@ -7,18 +7,16 @@ describe('withdraw.spec.ts', () => {
 			const value = true
 
 			const withdrawContract = {
-				methods: {
+				withdraw: jest
+					.fn()
 					// eslint-disable-next-line @typescript-eslint/no-unused-vars
-					withdraw: (property: string) => ({
-						send: jest.fn().mockImplementation(async () => stubbedSendTx()),
-					}),
-				},
+					.mockImplementation(async (property: string) => stubbedSendTx()),
 			}
 
 			const expected = value
 
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			const caller = createWithdrawCaller(withdrawContract as any, stubbedWeb3)
+			const caller = createWithdrawCaller(withdrawContract as any)
 
 			const result = await caller('0x80a25ACDD0797dfCe02dA25e4a55A4a334EE51c5')
 
@@ -26,25 +24,18 @@ describe('withdraw.spec.ts', () => {
 		})
 
 		it('call failure', async () => {
+			const address = '0x80a25ACDD0797dfCe02dA25e4a55A4a334EE51c5'
+			const err = new Error('error')
 			const withdrawContract = {
-				methods: {
+				withdraw: jest
+					.fn()
 					// eslint-disable-next-line @typescript-eslint/no-unused-vars
-					withdraw: (property: string) => ({
-						send: jest
-							.fn()
-							.mockImplementation(async () => stubbedSendTx(undefined, true)),
-					}),
-				},
+					.mockImplementation(async (property: string) => Promise.reject(err)),
 			}
 
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			const caller = createWithdrawCaller(withdrawContract as any, stubbedWeb3)
-
-			const result = await caller(
-				'0x80a25ACDD0797dfCe02dA25e4a55A4a334EE51c5'
-			).catch((err) => err)
-
-			expect(result).toBeInstanceOf(Error)
+			const caller = createWithdrawCaller(withdrawContract as any)
+			await expect(caller(address)).rejects.toThrowError(err)
 		})
 	})
 })

--- a/lib/withdraw/withdraw.ts
+++ b/lib/withdraw/withdraw.ts
@@ -1,20 +1,16 @@
-/* eslint-disable @typescript-eslint/prefer-readonly-parameter-types */
-import { Contract } from 'web3-eth-contract/types'
-import Web3 from 'web3'
-import { execute } from '../utils/execute'
+import { ethers } from 'ethers'
+import { execute, MutationOption } from '../utils/execute'
 import { T } from 'ramda'
 
 export type CreateWithdrawCaller = (
-	contract: Contract,
-	client: Web3
+	contract: ethers.Contract
 ) => (propertyAddress: string) => Promise<boolean>
 
 export const createWithdrawCaller: CreateWithdrawCaller =
-	(contract: Contract, client: Web3) => async (propertyAddress) =>
-		execute({
+	(contract: ethers.Contract) => async (propertyAddress) =>
+		execute<MutationOption>({
 			contract,
 			method: 'withdraw',
 			mutation: true,
-			client,
 			args: [propertyAddress],
 		}).then(T)


### PR DESCRIPTION
Fixes #

## Proposed Changes

- I changed the provider of the withdraw API from web3 to ethers.js.

```sh
~/s/g/d/dev-kit-js ❯❯❯ yarn test lib/withdraw                                                                                                                                       ✘ 1 feature/ethers.js ✱
yarn run v1.22.11
$ jest lib/withdraw
 PASS  lib/withdraw/calculateRewardAmount.spec.ts (7.292 s)
 PASS  lib/withdraw/calculateWithdrawableAmount.spec.ts (7.342 s)
 PASS  lib/withdraw/getRewardsAmount.spec.ts (7.375 s)
 PASS  lib/withdraw/bulkWithdraw.spec.ts (7.724 s)
 PASS  lib/withdraw/index.spec.ts (8.379 s)
 PASS  lib/withdraw/withdraw.spec.ts (8.96 s)

Test Suites: 6 passed, 6 total
Tests:       11 passed, 11 total
Snapshots:   0 total
Time:        9.457 s
Ran all test suites matching /lib\/withdraw/i.
```